### PR TITLE
Remove unused lib/forge-std submodule (closes #21)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "lib/forge-std"]
-	path = lib/forge-std
-	url = https://github.com/foundry-rs/forge-std


### PR DESCRIPTION
Closes #21.

## Summary

PR #19 switched the IERC165 binding from a path-based \`sol!(\"lib/forge-std/src/interfaces/IERC165.sol\")\` to an inline \`sol! { #[sol(rpc)] interface IERC165 { ... } }\`. Nothing in this repo reads \`lib/forge-std/\` afterwards — there's no \`foundry.toml\`, no \`test/\`, no \`script/\`, no \`.sol\` source.

## Changes
- Drop the \`lib/forge-std\` submodule entry.
- Drop \`.gitmodules\` (no other submodules).

## Test plan
- [x] \`cargo test --lib erc165\` — 19 tests pass locally
- [ ] CI green (Rainix CI)

## Follow-ups (separate issues)
- #22 — README still describes the pre-PR-19 ethers/alloy bridge surface.
- #23 — Init \`CLAUDE.md\` for this repo.
- #24 — Audit pass over the post-refactor surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)