### PR TITLE
chore: release rain-erc 0.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rain-erc"
-version = "0.0.0"
+version = "0.1.0"
 edition = "2021"
 description = "Provides ERC related utitlies in rust"
 license = "CAL-1.0"


### PR DESCRIPTION
First stable publish to crates.io. Unblocks rain.metadata + rainlang publish chains.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.1.0

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rainlanguage/rain.erc/pull/26?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->