### PR TITLE
docs: README for rain-erc 0.1.0 Rust-only crate

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,53 @@
-# rain.erc
+# rain-erc
+
+ERC-related utilities for the Rain Protocol ecosystem, in Rust.
+
+[![crates.io](https://img.shields.io/crates/v/rain-erc.svg)](https://crates.io/crates/rain-erc)
+[![docs.rs](https://docs.rs/rain-erc/badge.svg)](https://docs.rs/rain-erc)
+
+## What's here
+
+- `erc165` — Probe arbitrary contracts for `IERC165` support. The probe is
+  spec-compliant: it distinguishes execution-revert results (treated as
+  "interface not supported", per
+  [EIP-165](https://eips.ethereum.org/EIPS/eip-165)) from genuine RPC / decoding
+  errors (returned as `Err`). Works against any `alloy::providers::Provider`.
+
+## Install
+
+```toml
+[dependencies]
+rain-erc = "0.1"
+```
+
+## Use
+
+```rust
+use alloy::primitives::Address;
+use alloy::providers::ProviderBuilder;
+use rain_erc::erc165::supports_erc165;
+
+let provider = ProviderBuilder::new().connect_http("https://...".parse()?);
+let contract: Address = "0x...".parse()?;
+
+if supports_erc165(&provider, contract).await? {
+    // contract responds correctly to ERC-165 probes
+}
+```
+
+## Develop
+
+Requires Nix with flakes:
+
+```sh
+nix develop                    # default = rust-shell (slim Rust toolchain)
+nix develop -c cargo test
+nix develop -c cargo clippy
+```
+
+CI runs via [rainlanguage/rainix](https://github.com/rainlanguage/rainix)
+reusable workflows.
+
+## License
+
+CAL-1.0.


### PR DESCRIPTION
Replaces the single-line README with a proper Rust-only crate one — what's in the crate (erc165 probe), how to install from crates.io, a short usage snippet, dev workflow via nix, license.

Closes #22.