### PR TITLE
ci: autopublish via rainix reusable workflow

### DIFF
--- a/.github/workflows/package-release.yaml
+++ b/.github/workflows/package-release.yaml
@@ -1,0 +1,11 @@
+name: Package Release
+on:
+  push:
+    branches:
+      - main
+jobs:
+  release:
+    uses: rainlanguage/rainix/.github/workflows/rainix-rs-autopublish.yaml@main
+    with:
+      crate: rain-erc
+    secrets: inherit

--- a/.github/workflows/package-release.yaml
+++ b/.github/workflows/package-release.yaml
@@ -5,7 +5,7 @@ on:
       - main
 jobs:
   release:
-    uses: rainlanguage/rainix/.github/workflows/rainix-rs-autopublish.yaml@main
+    uses: rainlanguage/rainix/.github/workflows/rainix-autopublish.yaml@main
     with:
       crate: rain-erc
     secrets: inherit


### PR DESCRIPTION
Thin caller of rainix-rs-autopublish (rainlanguage/rainix#178). Pure-Rust crate; everything else is in the upstream reusable.

Blocked on rainlanguage/rainix#178 merging — until then the @main reference resolves to a non-existent path and the workflow won't run. Once rainix#178 lands, every push to rain.erc main that changes the crate will tag + publish to crates.io automatically.