### PR TITLE
test(erc4626): mutation-validated coverage for BatchState assembly logic

### DIFF
--- a/src/erc4626/mod.rs
+++ b/src/erc4626/mod.rs
@@ -741,4 +741,151 @@ mod tests {
     fn test_format_units_rejects_scale_overflow() {
         assert!(format_units(U256::from(1u64), u8::MAX).is_err());
     }
+
+    // A BatchState carrying every field populated with valid data, so
+    // `into_item` takes the success path. Individual tests clear one
+    // field (or pre-seed an error) to drive a single branch of the
+    // error-precedence state machine.
+    fn complete_state() -> BatchState {
+        BatchState {
+            vault_address: Address::repeat_byte(0x11),
+            share_decimals: Some(18),
+            asset_address: Some(Address::repeat_byte(0xaa)),
+            asset_decimals: Some(6),
+            shares: Some(U256::from(10).pow(U256::from(18))),
+            assets: Some(U256::from(1_500_000u64)),
+            error: None,
+        }
+    }
+
+    #[test]
+    fn test_set_error_keeps_first() {
+        // set_error is first-wins: a later error must not clobber an
+        // earlier one. Pins the `if self.error.is_none()` guard.
+        let mut state = complete_state();
+        state.set_error("first");
+        state.set_error("second");
+        assert_eq!(state.error.as_deref(), Some("first"));
+    }
+
+    #[test]
+    fn test_set_error_sets_when_empty() {
+        // The other side of the guard: an empty error slot does get
+        // filled. Without this, a mutant that no-ops set_error entirely
+        // would survive the first-wins test above.
+        let mut state = complete_state();
+        assert!(state.error.is_none());
+        state.set_error("only");
+        assert_eq!(state.error.as_deref(), Some("only"));
+    }
+
+    #[test]
+    fn test_into_item_complete_state_succeeds() {
+        // All fields present, no error: success with populated data and
+        // no error string. Anchors the (None, false) arm and the
+        // success path of the value match.
+        let item = complete_state().into_item();
+        assert!(item.success);
+        assert!(item.error.is_none());
+        let data = item.data.as_ref().unwrap();
+        assert_eq!(data.share_token_address, Address::repeat_byte(0x11));
+        assert_eq!(data.share_token_decimals, 18);
+        assert_eq!(data.asset_address, Address::repeat_byte(0xaa));
+        assert_eq!(data.asset_decimals, 6);
+        assert_eq!(data.shares, U256::from(10).pow(U256::from(18)));
+        assert_eq!(data.assets, U256::from(1_500_000u64));
+        assert_eq!(data.shares_display, "1");
+        assert_eq!(data.assets_display, "1.5");
+    }
+
+    #[test]
+    fn test_into_item_incomplete_without_error_synthesizes_message() {
+        // A state that completed its reads without an explicit error but
+        // is missing a field (here `assets`) must NOT silently report
+        // success: into_item synthesizes the sentinel error and marks
+        // the item failed. Pins the `(None, true)` arm and its exact
+        // message — a mutant that drops the synthesized error (returns
+        // None) or changes the string is killed.
+        let mut state = complete_state();
+        state.assets = None;
+        let item = state.into_item();
+        assert!(!item.success);
+        assert!(item.data.is_none());
+        assert_eq!(
+            item.error.as_deref(),
+            Some("Incomplete ERC4626 batch result")
+        );
+    }
+
+    #[test]
+    fn test_into_item_existing_error_takes_precedence_over_synthesized() {
+        // When a real error was already recorded AND data is missing,
+        // the recorded error must win over the synthesized "Incomplete"
+        // sentinel. Distinguishes the `(Some, true)` arm from the
+        // `(None, true)` arm.
+        let mut state = complete_state();
+        state.assets = None;
+        state.set_error("asset call failed at index 3");
+        let item = state.into_item();
+        assert!(!item.success);
+        assert!(item.data.is_none());
+        assert_eq!(item.error.as_deref(), Some("asset call failed at index 3"));
+    }
+
+    #[test]
+    fn test_into_item_error_present_with_data_reports_failure() {
+        // A pre-seeded error must survive even when every field is
+        // present and a conversion could be built: the item reports
+        // failure and surfaces the recorded error. Pins the
+        // error-wins precedence (the `(Some(error), _)` arm) — a mutant
+        // that drops the error whenever data exists is killed. Whether
+        // `data` is populated alongside is an implementation detail this
+        // test deliberately does not constrain.
+        let mut state = complete_state();
+        state.set_error("share decimals call failed at index 0");
+        let item = state.into_item();
+        assert!(!item.success);
+        assert_eq!(
+            item.error.as_deref(),
+            Some("share decimals call failed at index 0")
+        );
+    }
+
+    #[test]
+    fn test_into_item_build_conversion_error_recorded() {
+        // All fields present but a field forces build_conversion to
+        // fail (decimals = u8::MAX overflows decimal_scale). The
+        // resulting error must be recorded and the item marked failed
+        // with no data. Pins the `Err(err)` arm inside into_item that
+        // folds a build_conversion failure into the state error.
+        let mut state = complete_state();
+        state.asset_decimals = Some(u8::MAX);
+        let item = state.into_item();
+        assert!(!item.success);
+        assert!(item.data.is_none());
+        assert!(item
+            .error
+            .as_deref()
+            .unwrap()
+            .contains("decimal scale overflow"));
+    }
+
+    #[test]
+    fn test_multicall_failure_message_includes_label_index_and_data() {
+        // The per-call failure message must interpolate the label, the
+        // exact failing index, and the return data. The batch tests only
+        // assert the label substring, so the index and return-data
+        // fields are otherwise unpinned.
+        let msg = multicall_failure(
+            "asset",
+            Failure {
+                idx: 7,
+                return_data: vec![0xde, 0xad, 0xbe, 0xef].into(),
+            },
+        );
+        assert_eq!(
+            msg,
+            "asset call failed at index 7 with return data: 0xdeadbeef"
+        );
+    }
 }


### PR DESCRIPTION
## What

Incremental, **tests-only** coverage hardening for the `erc4626` module, toward the end-to-end audit in #24. This pass targets one coherent group: the per-vault **batch-item assembly logic** in `BatchState` — `set_error`, `into_item`'s error-precedence state machine, and `multicall_failure`.

Production code is **unchanged** (`git diff` touches only the `#[cfg(test)] mod tests` block of `src/erc4626/mod.rs`, +147 lines). Each new test was written under adversarial-mutation discipline: it **passes on clean code and fails under a single targeted source mutation**, then the mutation was restored.

## Why this group

`erc4626` landed recently (#32) and its happy-path batch tests exercise the multicall plumbing but don't discriminate the pure error-assembly logic. Mutation probing surfaced five surviving mutants there (a `format_units` boundary and `decimal_scale` were already well covered and are left as-is).

## Mutation matrix (behavior → mutation applied → killing test)

| # | Behavior (source) | Mutation | Result on existing suite | Killing test (new) |
|---|---|---|---|---|
| M1 | `format_units` overflow guard `fractional.len() > width` | `>` → `>=` | **killed** (existing `test_format_units`, "1.5" has len==width) | — already covered |
| M2 | `into_item` synthesized sentinel, `(None, true)` arm | `Some("Incomplete ERC4626 batch result")` → `None` | survived | `test_into_item_incomplete_without_error_synthesizes_message` |
| M3 | `set_error` first-wins guard `if self.error.is_none()` | drop guard (always overwrite) | survived | `test_set_error_keeps_first` |
| M4 | `into_item` error-vs-data precedence `(Some(error), _)` | drop error when data present | survived | `test_into_item_error_present_with_data_reports_failure` |
| M5 | `multicall_failure` index interpolation `failure.idx` | `failure.idx` → `0` | survived | `test_multicall_failure_message_includes_label_index_and_data` |
| M6 | `multicall_failure` return-data interpolation | (covered by the exact-string `assert_eq!` in M5's test) | — | same test |
| M7 | `into_item` `build_conversion` failure fold (`Err(err)` arm) | drop recorded error | survived | `test_into_item_build_conversion_error_recorded` |

Supporting tests added for non-redundancy / branch anchoring: `test_set_error_sets_when_empty` (kills a no-op `set_error` mutant that the first-wins test alone would miss), `test_into_item_complete_state_succeeds` (anchors the `(None, false)` success arm), `test_into_item_existing_error_takes_precedence_over_synthesized` (distinguishes `(Some, true)` from `(None, true)`).

## Verify

- `cargo build` / `cargo test`: **33 passed, 0 failed** (was 25). All mocked (`Asserter`); no RPC/fork dependencies.
- `cargo fmt --all -- --check`: clean.
- `cargo clippy --all-targets --all-features -- -D warnings -D clippy::all`: clean.
- `git diff` is tests-only; production lines verified byte-identical to the base.

## Incremental toward #24 — gaps still uncovered (checklist for the next pass)

This is **Refs #24, not Closes** — the audit covers the whole repo; this pass hardened one group.

erc4626 — not yet mutation-audited:
- [ ] `read_share_decimals` default-shares fill (`if state.error.is_none() && state.shares.is_none()` + `decimal_scale` fold) — branch + ordering.
- [ ] `read_asset_decimals` / `read_converted_assets` skip logic (`if state.error.is_some() { continue }`, `if call_indexes.is_empty() { return }`) and the `call_indexes`→results zip alignment.
- [ ] `batch_share_ratios` empty-vaults short-circuit (`if !states.is_empty()`), block-id pinning, and the global-failure (`?`) propagation paths.
- [ ] `current_block_timestamp` `.to()` conversion and multicall wiring.
- [ ] `format_units` trailing-zero trim / zero-fractional early return as standalone units (currently only exercised via batch displays).
- [ ] thin single-vault wrappers (`share_ratio`, `share_decimals`, `asset`, `convert_to_assets`, `convert_to_shares`) and `Erc4626BatchVault::with_shares`.
- [ ] `Erc4626Error` `#[from]` conversions (Contract / Transport / Multicall) and serde round-trips of the response/item structs.

erc165 — already has thorough mutation-style coverage (both checks, revert/zero-data/transport paths, `xor_selectors` single/two/empty). Worth a confirmatory mutation pass but lower priority.

Repo hygiene items from #24 (README #22, CLAUDE.md #23 — landed; pinning/CI shape) are out of scope for this tests-only PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)