### PR TITLE
test(erc165): mutation-validated confirmatory pass + close NoSelectors gap

### DIFF
--- a/src/erc165/mod.rs
+++ b/src/erc165/mod.rs
@@ -177,10 +177,57 @@ mod tests {
         }
     }
 
-    // No empty-interface fixture: the `sol!` macro does not generate
-    // a `Calls` enum for an interface with zero functions, so the
+    // The `sol!` macro does not generate a `Calls` enum for an
+    // interface with zero functions, so the
     // `XorSelectorsError::NoSelectors` branch is only reachable via a
-    // hand-rolled `SolInterface` impl. It stays as a defensive guard.
+    // hand-rolled `SolInterface` whose `selectors()` is empty. This
+    // uninhabited type provides exactly that: `COUNT == 0`, so
+    // `selectors()` yields no items and `xor_selectors` must hit the
+    // empty guard.
+    enum EmptyInterface {}
+
+    impl SolInterface for EmptyInterface {
+        const NAME: &'static str = "EmptyInterface";
+        const MIN_DATA_LENGTH: usize = 0;
+        const COUNT: usize = 0;
+
+        fn selector(&self) -> [u8; 4] {
+            match *self {}
+        }
+
+        fn selector_at(_i: usize) -> Option<[u8; 4]> {
+            None
+        }
+
+        fn valid_selector(_selector: [u8; 4]) -> bool {
+            false
+        }
+
+        fn abi_decode_raw(_selector: [u8; 4], _data: &[u8]) -> alloy::sol_types::Result<Self> {
+            Err(alloy::sol_types::Error::UnknownSelector {
+                name: Self::NAME,
+                selector: [0; 4].into(),
+            })
+        }
+
+        fn abi_decode_raw_validate(
+            _selector: [u8; 4],
+            _data: &[u8],
+        ) -> alloy::sol_types::Result<Self> {
+            Err(alloy::sol_types::Error::UnknownSelector {
+                name: Self::NAME,
+                selector: [0; 4].into(),
+            })
+        }
+
+        fn abi_encoded_size(&self) -> usize {
+            match *self {}
+        }
+
+        fn abi_encode_raw(&self, _out: &mut Vec<u8>) {
+            match *self {}
+        }
+    }
 
     fn mocked_provider(asserter: Asserter) -> impl Provider {
         ProviderBuilder::new().connect_mocked_client(asserter)
@@ -242,6 +289,18 @@ mod tests {
         // (that would be the single-selector path).
         assert_ne!(result, selectors[0]);
         assert_ne!(result, selectors[1]);
+    }
+
+    #[test]
+    fn test_xor_selectors_empty_interface_errors() {
+        // An interface with no selectors must yield the NoSelectors
+        // error rather than indexing `selectors[0]` (which would panic)
+        // or returning some default. Pins the `selectors.is_empty()`
+        // guard and its exact error variant — a mutant that drops the
+        // guard would panic on the empty-slice index, and one that
+        // returns a different error variant is caught by the match.
+        let err = EmptyInterface::xor_selectors().unwrap_err();
+        assert!(matches!(err, XorSelectorsError::NoSelectors));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What

Confirmatory, **tests-only** adversarial-mutation pass over the **`erc165`** module, toward the end-to-end audit in #24. This is the "confirmatory mutation pass" that #33's gaps checklist explicitly flagged as outstanding for erc165.

Production code is **unchanged** — `git diff` touches only the `#[cfg(test)] mod tests` block of `src/erc165/mod.rs` (lines 1-139 are byte-identical to base; +62/-3, the deletions are a rewritten test-module comment). Non-overlapping with #33, which hardens `src/erc4626/mod.rs`.

## Method

For every behavior in the module I mutated the exact source line, ran `cargo test`, and recorded whether the existing suite killed it. Survivors got a new discriminating test that passes clean and fails under the mutation; every mutation was restored (final `git diff` of production code is empty).

## Result: one genuine gap found and closed

erc165 was already **near-saturated** — 12 of 13 mutants were killed by the existing suite. **One genuinely survived:** the `XorSelectorsError::NoSelectors` empty-selectors guard had no test. The source comment itself admitted it was an untested defensive branch (the `sol!` macro never emits a `Calls` enum for a zero-function interface, so the branch is unreachable through generated bindings). I added an **uninhabited hand-rolled `SolInterface`** (`COUNT == 0`, so `selectors()` is empty) and `test_xor_selectors_empty_interface_errors`, which now kills that mutant (without the guard, `selectors[0]` panics on the empty slice).

Note: #33's checklist listed erc165 as covering "`xor_selectors` single/two/**empty**" — the empty case was in fact the one untested branch; this PR closes it.

## Mutation matrix (behavior → mutation applied → outcome / killer)

| # | Behavior (source) | Mutation | Outcome |
|---|---|---|---|
| M1 | `is_revert_like` ZeroData disjunct | drop `\|\| matches!(e, ZeroData)` | **killed** — `test_supports_erc165_check1_zero_data_response` |
| M2 | `is_revert_like` revert-data disjunct | drop `as_revert_data().is_some() \|\|` | **killed** — the four `*_revert*`/`*_reverts*` tests |
| M3 | `xor_selectors` loop body | `^=` → `\|=` | **killed** — `test_get_interface_id`, `test_xor_selectors_two_function_interface_xors_both` |
| M4 | `xor_selectors` loop range / init | `&selectors[1..]` → `&selectors[..]` (double-folds index 0) | **killed** — single/two/`get_interface_id` xor tests |
| M5 | `xor_selectors` empty guard | `if selectors.is_empty()` → `if false` | **survived → fixed** — new `test_xor_selectors_empty_interface_errors` |
| M6 | `check2` result negation | `Ok(!v)` → `Ok(v)` | **killed** — `check2_returns_true/false`, `check2_fails`, `both_checks_pass` |
| M7 | `supports_erc165` short-circuit condition | `if !check1` → `if check1` | **killed** — `both_checks_pass`, `check1_fails`, `check1_reverts`, `propagates_check2_transport_error` |
| M8 | `supports_erc165` short-circuit return value | `return Ok(false)` → `Ok(true)` | **killed** — `check1_fails`, `check1_reverts` |
| M9 | `supports_erc165` check2 tail propagation | ignore check2, `Ok(true)` | **killed** — `check2_fails`, `check2_reverts_after_check1_passes`, `propagates_check2_transport_error` |
| M10 | `check1` revert arm | `Ok(false)` → `Ok(true)` | **killed** — `check1_revert_response`, `check1_zero_data_response`, `check1_reverts` |
| M11 | `check2` revert arm | `Ok(false)` → `Ok(true)` | **killed** — `check2_reverts`, `check2_reverts_after_check1_passes` |
| M12 | `check1` transport fall-through | `Err(e.into())` → `Ok(false)` | **killed** — `check1_transport_error_propagates`, `propagates_check1_transport_error` |
| M13 | `check2` transport fall-through | `Err(e.into())` → `Ok(false)` | **killed** — `check2_transport_error_propagates`, `propagates_check2_transport_error` |

## Verify

- `cargo build` / `cargo test`: **26 passed, 0 failed** (was 25 on this base; +1 new test). All mocked via `Asserter`; no RPC/fork dependencies.
- `cargo fmt --all -- --check`: clean.
- `cargo clippy --all-targets --all-features -- -D warnings -D clippy::all`: clean.
- `git diff` is tests-only; production lines (1-139) verified byte-identical to base.

## Incremental toward #24 — gaps still uncovered (checklist for the next pass)

**Refs #24, not Closes** — this pass hardened one module group.

erc165 — **now fully mutation-saturated** (every behavior probed; the one survivor closed). No further erc165 work expected.

erc4626 — not yet mutation-audited (and **out of scope here / owned by #33** for the batch-item assembly group). Remaining for future passes, none colliding with this PR's file:
- [ ] `read_share_decimals` default-shares fill + `decimal_scale` fold ordering.
- [ ] `read_asset_decimals` / `read_converted_assets` skip logic and the `call_indexes`→results zip alignment.
- [ ] `batch_share_ratios` empty-vaults short-circuit, block-id pinning, global-failure (`?`) propagation.
- [ ] `current_block_timestamp` `.to()` conversion and multicall wiring.
- [ ] `format_units` trailing-zero trim / zero-fractional early return as standalone units.
- [ ] thin single-vault wrappers (`share_ratio`, `share_decimals`, `asset`, `convert_to_assets`, `convert_to_shares`) and `Erc4626BatchVault::with_shares`.
- [ ] `Erc4626Error` `#[from]` conversions (Contract / Transport / Multicall) and serde round-trips.

(Note: the `Erc4626Error`/helper groups mentioned as candidates for this pass live in the same `mod tests` block as #33's additions in `src/erc4626/mod.rs`, so they were deferred to avoid a merge collision; erc165 — a separate file — was chosen instead.)

Refs #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)